### PR TITLE
PCQ-698 - Removed the health-springboot-starter from the build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,6 @@ dependencies {
     compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 
     compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.0.4', withoutSpringCloudContext
-    compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.5'
     compile group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -267,6 +267,8 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '1.5.5'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.3'
 
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
+
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ-698


### Change description ###
Removed the health-springboot-starter from the build.gradle as the job fails after springboot upgrade to 2.3.4


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
