### PR TITLE
Incremented tomcat version to 9.0.39

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ configurations.all {
                 details.useVersion '2.12.10'
             }
             if (details.requested.group in ['org.apache.tomcat.embed']) {
-                details.useVersion '9.0.37'
+                details.useVersion '9.0.39'
             }
         }
     }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -232,4 +232,18 @@
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <cve>CVE-2017-18640</cve>
     </suppress>
+    <suppress until="2021-01-31">
+        <notes><![CDATA[
+   file name: tomcat-embed-core-9.0.39.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
+        <cve>CVE-2020-13943</cve>
+    </suppress>
+    <suppress until="2021-01-31">
+        <notes><![CDATA[
+   file name: tomcat-embed-websocket-9.0.39.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
+        <cve>CVE-2020-13943</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Nightly build fix to the dependency check error. The tomcat version has been upgraded to 9.0.39. Added temporary suppressions ( same as pcq-backend and pcq-loader).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
