### PR TITLE
PCQ-744-Added suppression for low severity CVE

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -232,4 +232,11 @@
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <cve>CVE-2017-18640</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: guava-28.2-jre.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-744


### Change description ###
Added suppression for the CVE-2020-8908 as its a low severity. The library and its functions are not used in the pcq-consolidation-service code.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
