### PR TITLE
PCQ-1141: Consolidation service dependency check fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,7 +315,7 @@ dependencies {
 
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.0.1'
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.7.RELEASE'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.10.RELEASE'
 
     compile group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     compile group: "com.networknt", name: "json-schema-validator", version: "1.0.31"


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/PCQ-1141

### Change description ###
- Update spring-cloud-starter-netflix-hystrix to version 2.2.10 as documented here: https://tanzu.vmware.com/security/cve-2021-22053
- Verified dependencyCheckAggregate passes locally

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```
