### PR TITLE
PCQ-1452: Suppress spring-plugin vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'pmd'
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-    id 'org.springframework.boot' version '2.6.6'
+    id 'org.springframework.boot' version '2.5.12'
     id 'org.owasp.dependencycheck' version '6.4.1.1'
     id 'com.github.ben-manes.versions' version '0.36.0'
     id "info.solidsoft.pitest" version '1.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -237,7 +237,6 @@ dependencyManagement {
         }
         // CVE-2021-29425
         dependency group: 'commons-io', name: 'commons-io', version: '2.11.0'
-
         dependencySet(group: 'org.springframework.security', version: '5.6.1') {
             entry 'spring-security-core'
             entry 'spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'pmd'
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-    id 'org.springframework.boot' version '2.5.9'
+    id 'org.springframework.boot' version '2.6.6'
     id 'org.owasp.dependencycheck' version '6.4.1.1'
     id 'com.github.ben-manes.versions' version '0.36.0'
     id "info.solidsoft.pitest" version '1.6.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -54,14 +54,6 @@
         <cve>CVE-2020-29582</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[
-       file name: kotlin-stdlib-*.jar
-   ]]></notes>
-        <filePath regex="true">.*kotlin-stdlib-(common-|jdk7-|jdk8-|)1\.4\.30\.jar</filePath>
-        <cve>CVE-2020-15824</cve>
-        <cve>CVE-2020-29582</cve>
-    </suppress>
-    <suppress>
         <notes><![CDATA[name: spring-plugin-core and spring-plugin-metadata 2.0.0.RELEASE]]></notes>
         <cve>CVE-2013-4152</cve>
         <cve>CVE-2013-7315</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -53,4 +53,18 @@
         <cve>CVE-2020-15824</cve>
         <cve>CVE-2020-29582</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: kotlin-stdlib-*.jar
+   ]]></notes>
+        <filePath regex="true">.*kotlin-stdlib-(common-|jdk7-|jdk8-|)1\.4\.30\.jar</filePath>
+        <cve>CVE-2020-15824</cve>
+        <cve>CVE-2020-29582</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[name: spring-plugin-core and spring-plugin-metadata 2.0.0.RELEASE]]></notes>
+        <cve>CVE-2013-4152</cve>
+        <cve>CVE-2013-7315</cve>
+        <cve>CVE-2014-0054</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-1452


### Change description ###
Update to springframework.boot 2.5.12 and suppress spring-plugin vulnerabilities.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
