### PR TITLE
Onboard CVE dashboard intake

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,7 +6,7 @@ properties([
   //pipelineTriggers([cron('H 05 * * *')])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@cve-dashboard")
 
 import uk.gov.hmcts.contino.GradleBuilder
 
@@ -41,6 +41,7 @@ def vaultOverrides = [
 ]
 
 withPipeline(type, product, component) {
+  enableCveDashboardIngestion()
 
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)


### PR DESCRIPTION
## Summary
- use the CVE dashboard Jenkins library branch
- enable CVE dashboard ingestion for the CNP pipeline

## Testing
- Not run; Jenkins pipeline configuration only