### PR TITLE
Re-onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,7 +6,7 @@ properties([
   //pipelineTriggers([cron('H 05 * * *')])
 ])
 
-@Library("Infrastructure@2.4.4")
+@Library("Infrastructure@cve-dashboard")
 
 import uk.gov.hmcts.contino.GradleBuilder
 
@@ -41,6 +41,7 @@ def vaultOverrides = [
 ]
 
 withPipeline(type, product, component) {
+  enableCveDashboardIngestion()
 
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)


### PR DESCRIPTION
## Summary
- pin the shared Jenkins library to cve-dashboard, now based on version 2.4.9
- enable CVE dashboard ingestion

## Testing
- Jenkinsfile-only configuration change